### PR TITLE
Add ufw firewall support, make group names unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Requirements
 
 - A PostgreSQL instance that Boundary workers can reach and authenticate to. The database you plan to use must also exist.
 - Access to a KMS solution. This role currently only supports Google Cloud KMS.
+- Nodes must be in inventory groups `boundary_controller` or `boundary_worker` to receive configuration for that service. 
+  A node in both groups is configured to run both services.
 
 Role Variables
 --------------
@@ -67,10 +69,10 @@ The following deploys a single Boundary controller and worker node.
 Create an inventory file:
 ```bash
 $ cat > inventory <<EOF
-[controllers]
+[boundary_controllers]
 192.168.0.100
 
-[workers]
+[boundary_workers]
 192.168.0.101
 EOF
 ```

--- a/tasks/boundary_config.yml
+++ b/tasks/boundary_config.yml
@@ -27,7 +27,7 @@
         name: boundary-worker
         enabled: yes
         state: started
-  when: "'workers' in group_names"
+  when: "'boundary_workers' in group_names"
 
 - name: templating out Boundary controller configuration
   block:
@@ -60,4 +60,4 @@
         name: boundary-controller
         enabled: yes
         state: started
-  when: "'controllers' in group_names"
+  when: "'boundary_controllers' in group_names"

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,54 @@
+---
+- name: collect facts about system services
+  service_facts:
+  register: services_state
+
+- name: Configure firewalld
+  when: "{{ ansible_facts.services['firewalld.service'].state == 'running' | bool }}"
+  block:
+    - name: open boundary-controller tcp port
+      when:
+        - "'boundary_controllers' in group_names"
+      firewalld:
+        port: "{{ item }}/tcp"
+        permanent: true
+        immediate: true
+        state: enabled
+      with_items:
+        - 9200
+
+    - name: open boundary-worker tcp port
+      when:
+        - "'boundary_workers' in group_names"
+      firewalld:
+        port: "{{ item }}/tcp"
+        permanent: true
+        immediate: true
+        state: enabled
+      with_items:
+        - 9202
+
+- name: Configure ufw firewall
+  when: "{{ ansible_facts.services['ufw.service'].state == 'running' | bool }}"
+  block:
+    - name: open boundary-controller tcp port
+      when: "'boundary_controllers' in group_names"
+      community.general.ufw:
+        name: Boundary Controller API
+        state: enabled
+        rule: limit
+        to_port: "{{ item }}"
+        proto: tcp
+      with_items:
+        - 9200
+
+    - name: open boundary-worker tcp port
+      when: "'boundary_workers' in group_names"
+      community.general.ufw:
+        name: Boundary Worker API
+        state: enabled
+        rule: limit
+        to_port: "{{ item }}"
+        proto: tcp
+      with_items:
+        - 9202

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,34 +13,8 @@
   service_facts:
   register: services_state
 
-- name: firewalld_running
-  when: services_state.ansible_facts.services['firewalld.service'].state == 'running'
-  set_fact:
-    manage_firewalld: true
-
-- name: open boundary-controller tcp port
-  when:
-    - "'controllers' in group_names"
-    - manage_firewalld|bool
-  firewalld:
-    port: "{{ item }}/tcp"
-    permanent: true
-    immediate: true
-    state: enabled
-  with_items:
-    - 9200
-
-- name: open boundary-worker tcp port
-  when:
-    - "'workers' in group_names"
-    - manage_firewalld|bool
-  firewalld:
-    port: "{{ item }}/tcp"
-    permanent: true
-    immediate: true
-    state: enabled
-  with_items:
-    - 9202
+- name: configure firewall
+  include: firewall.yml
 
 - name: installing boundary
   include: boundary_install.yml


### PR DESCRIPTION
Use boundary_ prefixed group names for larger inventory files where simply 'worker' is too vague/conflicting
Add ufw firewall support
Move firewall configuration to separate task file