### PR TITLE
WiP: Add AWS and AEAD KMS implementations and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-Ansible Role: HashiCorp Boundary
-=========
+# Ansible Role: HashiCorp Boundary
 
 A role to deploy [HashiCorp Boundary](https://www.boundaryproject.io/)
 
-Requirements
-------------
+## Requirements
 
 - A PostgreSQL instance that Boundary workers can reach and authenticate to. The database you plan to use must also exist.
 - Access to a KMS solution. This role currently only supports Google Cloud KMS.
@@ -61,66 +59,33 @@ If you are building a PoC to learn and explore, you may want to remove this valu
 boundary_db_init_flags: '-skip-initial-login-role'
 ```
 
-### Type of KMS to use.
+### Type of KMS
 
-```YAML
-boundary_kms_type: 'gcpckms'
-```
-Or
-```YAML
-boundary_kms_type: 'transit'
-```
+As these choices are radically different depending on your KMS, refer to one of these examples:
 
-Dependencies
-------------
+- [GCP CKMS](examples/kms_gcp.md)
+- [AWS KMS](examples/kms_aws.md)
+- [Hashicorp Vault - Transit secrets engine](examples/kms_transit.md)
+- [Static AEAD Keys](examples/kms_aead.md) - not suitable for production use
+
+## Dependencies
 
 None.
 
-Example Project with Vault KMS
-------------------------------
+## Instructions
+
+If you are new to Ansible playbooks and group vars, the following examples can guide you:
+
+- Creating [Boundary Playbook](examples/playbook.md)
+- Creating [Boundary Group Vars](examples/group_vars.md)
+
+## Example Project with Vault KMS
+
+The following is a project utilizing an early version of this module
+
 https://github.com/dockpack/vault\_dojo.git
 
-
-Example Playbook
-----------------
-The following deploys a single Boundary controller and worker node.
-
-Create an inventory file:
-```bash
-$ cat > inventory <<EOF
-[boundary_controllers]
-192.168.0.100
-
-[boundary_workers]
-192.168.0.101
-EOF
-```
-
-Create the group_vars directory and file:
-```bash
-# ensure the group_vars directory exists
-$ mkdir group_vars/
-
-# create the group_vars file for all hosts
-$ cat > group_vars/all.yml <<EOF
----
-boundary_psql_endpoint: ''
-boundary_psql_username: ''
-
-boundary_gcpckms_project: ''
-boundary_gcpckms_region: ''
-boundary_gcpckms_keyring: ''
-boundary_gcpckms_key: ''
-EOF
-```
-
-Run the playbook (Boundary PSQL password should be passed through a more secure method so it isn't shown in plaintext):
-```bash
-$ ansible-playbook -i inventory site.yml --extra-vars "boundary_psql_password=''"
-```
-
-Author Information
-------------------
+## Author Information
 
 Jacob Mammoliti
 Bas Meijer

--- a/examples/group_vars.md
+++ b/examples/group_vars.md
@@ -1,0 +1,45 @@
+# Ansible Role: HashiCorp Boundary group vars example
+
+## Create an inventory file
+
+Create an inventory file with groups for controllers and workers:
+
+```bash
+$ cat > inventory <<EOF
+[boundary_controllers]
+192.168.0.100
+
+[boundary_workers]
+192.168.0.101
+EOF
+```
+
+## Create the group_vars files
+
+```bash
+$ echo "---" > group_vars/boundary_workers.yml
+$ cat > group_vars/boundary_controllers.yml <<EOF
+---
+boundary_psql_endpoint: 'pgsql.example.com:5432'
+EOF
+```
+
+## Database credentials
+
+You'll need to source the username and password for the database from someplace secure.
+If you don't have a secrets vault deployed, follow the Ansible guide:
+
+[Encrypting content with Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
+
+Reference those secrets in the group vars.
+
+## KMS configuration
+
+As KMS configuration is radically different depending on your choice of KMS, refer to one of these examples:
+
+- [GCP CKMS](examples/kms_gcp.md)
+- [AWS KMS](examples/kms_aws.md)
+- [Hashicorp Vault - Transit secrets engine](examples/kms_transit.md)
+- [Static AEAD Keys](examples/kms_aead.md) - not suitable for production use
+
+These values will need to be added to the group vars.

--- a/examples/kms_aead.md
+++ b/examples/kms_aead.md
@@ -1,0 +1,24 @@
+# HashiCorp Boundary AEAD KMS configuration
+
+From: https://www.boundaryproject.io/docs/configuration/kms/aead
+> This is mostly used for dev workflows or testing. The key will be exposed to anyone that can view the configuration file.
+
+## Requirements
+
+* 3 unique base64-encoded AEAD keys
+
+## Configuration Steps
+
+Create a group_vars file for boundary controller nodes
+
+### `group_vars/boundary_controllers.yml`
+
+Add the base64-encoded AEAD keys for each type
+
+```YAML
+boundary_kms_type: 'aead'
+boundary_aead_keys:
+  root: '*REPLACE*ME*'
+  worker-auth: '*REPLACE*ME*'
+  recovery: '*REPLACE*ME*'
+```

--- a/examples/kms_aws.md
+++ b/examples/kms_aws.md
@@ -1,0 +1,48 @@
+# HashiCorp Boundary GCP KMS configuration
+
+Based on https://www.boundaryproject.io/docs/configuration/kms/awskms
+
+## Requirements
+
+* 3 AWS KMS keys
+* EC2 node's IAM role must have the following permissions on each KMS key:
+  * `kms:Encrypt`
+  * `kms:Decrypt`
+  * `kms:DescribeKey`
+
+Example Terraform implementation of these requirements:
+
+* https://github.com/hashicorp/boundary-reference-architecture/blob/main/deployment/aws/aws/iam.tf
+* https://github.com/hashicorp/boundary-reference-architecture/blob/main/deployment/aws/aws/kms.tf
+
+## Configuration Steps
+
+Create a group_vars file for boundary controller nodes
+
+### `group_vars/boundary_controllers.yml`
+
+Add the KMS instance details
+
+```YAML
+# KMS location and auth
+boundary_kms_type: 'awskms'
+boundary_awskms_region: 'us-east-1'
+```
+
+Add the KMS key ids for each type
+
+```YAML
+# KMS key IDs
+boundary_awskms_keys:
+  root: ''
+  worker-auth: ''
+  recovery: ''
+```
+
+## Utilizing a non-default KMS Endpoint
+
+This is useful when connecting to KMS over a VPC Endpoint. If not set, Boundary will use the default API endpoint for your region.
+
+```YAML
+boundary_awskms_endpoint: 'https://vpce-Foo-Bar.kms.us-east-1.vpce.amazonaws.com'
+```

--- a/examples/kms_gcp.md
+++ b/examples/kms_gcp.md
@@ -1,0 +1,34 @@
+# HashiCorp Boundary GCP KMS configuration
+
+Based on https://www.boundaryproject.io/docs/configuration/kms/gcpckms
+
+## Requirements
+
+* GCP CKMS Keyring with keys as declared below
+
+## Configuration Steps
+
+Create a group_vars file for boundary controller nodes
+
+### `group_vars/boundary_controllers.yml`
+
+Add the KMS instance details
+
+```YAML
+# KMS location and auth
+boundary_kms_type: 'gcpckms'
+boundary_gcpckms_project: 'foo-bar'
+boundary_gcpckms_credentials: '/etc/boundary.d/kms-credentials.json'
+boundary_gcpckms_region: 'us-central1'
+boundary_gcpckms_keyring: 'bar-foo'
+```
+
+Add the KMS key ids for each type
+
+```YAML
+# KMS key IDs
+boundary_gcpckms_keys:
+  root: ''
+  worker-auth: ''
+  recovery: ''
+```

--- a/examples/kms_transit.md
+++ b/examples/kms_transit.md
@@ -1,0 +1,44 @@
+# HashiCorp Boundary Vault Transit KMS configuration
+
+Based on https://www.boundaryproject.io/docs/configuration/kms/transit
+
+## Requirements
+
+* Hashicorp Vault implementation with Transit secret engine
+* `VAULT_TOKEN` environment variable for a session with these permissions https://www.boundaryproject.io/docs/configuration/kms/transit#authentication
+
+## Configuration Steps
+
+Create a group_vars file for boundary controller nodes
+
+### `group_vars/boundary_controllers.yml`
+
+Add the Vault transit keystore details
+
+```YAML
+# Required settings
+boundary_kms_type: 'transit'
+vault_instances:
+  - vault.example.com
+boundary_transit_mount_path: 'transit/'
+boundary_transit_namespace: 'ns1'
+
+# Optional settings - safe to leave these out or blank
+boundary_transit_disable_renewal: 'false'   # see https://www.boundaryproject.io/docs/configuration/kms/transit#disable_renewal
+boundary_transit_tls_skip_verify: 'false'   # really, don't enable this
+boundary_transit_tls_server_name: 'vault.example.com'
+boundary_transit_tls_ca_cert: '/etc/ssl/certs/vault-ca.cert'
+boundary_transit_tls_ca_cert: '/etc/ssl/certs/vault-ca.cert'
+boundary_transit_tls_client_cert: '/etc/ssl/certs/vault-client.cert'
+boundary_transit_tls_client_key: '/etc/ssl/private/vault-client.key'
+```
+
+Add the key names for each type
+
+```YAML
+# KMS key IDs
+boundary_transit_keys:
+  root: '*change_me*'
+  worker-auth: '*change_me*'
+  recovery: '*change_me*'
+```

--- a/examples/playbook.md
+++ b/examples/playbook.md
@@ -1,0 +1,24 @@
+# Ansible Playbook: HashiCorp Boundary
+
+The following playbook deploys a single [HashiCorp Boundary](https://www.boundaryproject.io/) controller and worker node using *ansible-boundary-role*.
+
+This assumes you've [created the inventory and group vars files](group_vars.md) as documented.
+
+## Create the Ansible playbook
+
+```bash
+$ cat > playbooks/boundary.yml <<EOF
+- hosts: boundary_controllers,boundary_workers
+  become: yes
+  roles:
+    - role: boundary
+      tags: boundary
+```
+
+## Run the playbook
+
+Pass the appropriate arguments for decrypting the database secrets:
+
+```bash
+$ ansible-playbook -i inventory playbooks/boundary.yml --ask-vault-pass
+```

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -5,7 +5,7 @@ controller {
   description = "Boundary controller."
 
   database {
-      url = "postgresql://{{ boundary_psql_username }}:{{ boundary_psql_password }}@{{ boundary_psql_endpoint }}/{{ boundary_psql_dbname }}""
+      url = "postgresql://{{ boundary_psql_username }}:{{ boundary_psql_password }}@{{ boundary_psql_endpoint }}/{{ boundary_psql_dbname }}"
   }
 }
 
@@ -35,66 +35,50 @@ listener "tcp" {
   tls_disable = {{ boundary_tls_disable | lower }}
 }
 
-{% if boundary_kms_type == 'gcpckms' %}
+{% for key_type in ['root', 'worker-auth', 'recovery'] %}
+{% if boundary_kms_type == 'aead' %}
+kms "aead" {
+  purpose   = "{{ key_type }}"
+  aead_type = "aes-gcm"
+  key_id    = "global_{{ key_type }}"
+  key       = "{{ boundary_aead_keys[key_type] }}"
+}
+{% elif boundary_kms_type == 'awskms' %}
+kms "awskms" {
+  purpose    = "{{ key_type }}"
+  region     = "{{ region }}"
+  kms_key_id = "{{ boundary_awskms_keys[key_type] }}"
+{% if boundary_awskms_endpoint != '' %}
+  endpoint   = "{{ boundary_awskms_endpoint }}"
+{% endif %}
+}
+{% elif boundary_kms_type == 'gcpckms' %}
 kms "gcpckms" {
-  purpose     = "root"
+  purpose     = "{{ key_type }}"
+  credentials = "{{ boundary_gcpckms_credentials }}"
   project     = "{{ boundary_gcpckms_project }}"
   region      = "{{ boundary_gcpckms_region }}"
   key_ring    = "{{ boundary_gcpckms_keyring }}"
-  crypto_key  = "{{ boundary_gcpckms_key }}"
+  crypto_key  = "{{ boundary_gcpckms_keys[key_type] }}"
 }
-
-kms "gcpckms" {
-  purpose     = "worker-auth"
-  project     = "{{ boundary_gcpckms_project }}"
-  region      = "{{ boundary_gcpckms_region }}"
-  key_ring    = "{{ boundary_gcpckms_keyring }}"
-  crypto_key  = "{{ boundary_gcpckms_key }}"
-}
-
-kms "gcpckms" {
-  purpose     = "recovery"
-  project     = "{{ boundary_gcpckms_project }}"
-  region      = "{{ boundary_gcpckms_region }}"
-  key_ring    = "{{ boundary_gcpckms_keyring }}"
-  crypto_key  = "{{ boundary_gcpckms_key }}"
-}
-
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
-  purpose            = "root"
+  purpose            = "{{ key_type }}"
   address            = "https://{{ groups.vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
-  disable_renewal    = "false"
+  disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
   // Key configuration
-  key_name           = "transit_key_name"
-  mount_path         = "transit/"
-  namespace          = "ns1/"
+  mount_path         = "{{ boundary_transit_mount_path }}"
+  namespace          = "{{ boundary_transit_namespace }}"
+  key_name           = "{{ boundary_transit_keys[key_type] }}"
 
   // TLS Configuration
-  tls_ca_cert        = "{{ boundary_tls_config_path }}/{{ boundary_tls_ca_file }}"
-  tls_client_cert    = "{{ boundary_tls_config_path }}/{{ boundary_tls_cert_file }}"
-  tls_client_key     = "{{ boundary_tls_config_path }}/{{ boundary_tls_key_file }}"
-  tls_server_name    = "{{ groups.vault_instances[0] }}"
-  tls_skip_verify    = "false"
-}
-kms "transit" {
-  purpose            = "worker-auth"
-  address            = "https://{{ groups.vault_instances[0] }}:8200"
-  token              = "{{ lookup('env','VAULT_TOKEN') }}"
-  disable_renewal    = "false"
-
-  // Key configuration
-  key_name           = "transit_key_name"
-  mount_path         = "transit/"
-  namespace          = "ns1/"
-
-  // TLS Configuration
-  tls_ca_cert        = "{{ boundary_tls_config_path }}/{{ boundary_tls_ca_file }}"
-  tls_client_cert    = "{{ boundary_tls_config_path }}/{{ boundary_tls_cert_file }}"
-  tls_client_key     = "{{ boundary_tls_config_path }}/{{ boundary_tls_key_file }}"
-  tls_server_name    = "{{ groups.vault_instances[0] }}"
-  tls_skip_verify    = "false"
+  tls_server_name    = "{{ boundary_transit_tls_server_name |default(groups.vault_instances[0]) }}"
+  tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
+  tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
+  tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"
+  tls_skip_verify    = "{{ boundary_transit_tls_skip_verify |default('false') }}"
 }
 {% endif %}
+{% endfor %}

--- a/templates/boundary-worker.hcl.j2
+++ b/templates/boundary-worker.hcl.j2
@@ -17,32 +17,50 @@ worker {
   public_addr = "{{ inventory_hostname }}"
 }
 
-{% if boundary_kms_type == 'gcpckms' %}
+% for key_type in ['worker-auth'] %}
+{% if boundary_kms_type == 'aead' %}
+kms "aead" {
+  purpose   = "{{ key_type }}"
+  aead_type = "aes-gcm"
+  key_id    = "global_{{ key_type }}"
+  key       = "{{ boundary_aead_keys[key_type] }}"
+}
+{% elif boundary_kms_type == 'awskms' %}
+kms "awskms" {
+  purpose    = "{{ key_type }}"
+  region     = "{{ region }}"
+  kms_key_id = "{{ boundary_awskms_keys[key_type] }}"
+{% if boundary_awskms_endpoint != '' %}
+  endpoint   = "{{ boundary_awskms_endpoint }}"
+{% endif %}
+}
+{% elif boundary_kms_type == 'gcpckms' %}
 kms "gcpckms" {
-  purpose     = "worker-auth"
+  purpose     = "{{ key_type }}"
+  credentials = "{{ boundary_gcpckms_credentials }}"
   project     = "{{ boundary_gcpckms_project }}"
   region      = "{{ boundary_gcpckms_region }}"
   key_ring    = "{{ boundary_gcpckms_keyring }}"
-  crypto_key  = "{{ boundary_gcpckms_key }}"
+  crypto_key  = "{{ boundary_gcpckms_keys[key_type] }}"
 }
 {% elif boundary_kms_type == 'transit' %}
 kms "transit" {
-  purpose            = "worker-auth"
+  purpose            = "{{ key_type }}"
   address            = "https://{{ groups.vault_instances[0] }}:8200"
   token              = "{{ lookup('env','VAULT_TOKEN') }}"
-  disable_renewal    = "false"
+  disable_renewal    = "{{ boundary_transit_disable_renewal |default('false') }}"
 
   // Key configuration
-  key_name           = "transit_key_name"
-  mount_path         = "transit/"
-  namespace          = "ns1/"
+  mount_path         = "{{ boundary_transit_mount_path }}"
+  namespace          = "{{ boundary_transit_namespace }}"
+  key_name           = "{{ boundary_transit_keys[key_type] }}"
 
   // TLS Configuration
-  tls_ca_cert        = "{{ boundary_tls_config_path }}/{{ boundary_tls_ca_file }}"
-  tls_client_cert    = "{{ boundary_tls_config_path }}/{{ boundary_tls_cert_file }}"
-  tls_client_key     = "{{ boundary_tls_config_path }}/{{ boundary_tls_key_file }}"
-  tls_server_name    = "{{ groups.vault_instances[0] }}"
-  tls_skip_verify    = "false"
+  tls_server_name    = "{{ boundary_transit_tls_server_name |default(groups.vault_instances[0]) }}"
+  tls_ca_cert        = "{{ boundary_transit_tls_ca_file     |default('') }}"
+  tls_client_cert    = "{{ boundary_transit_tls_cert_file   |default('') }}"
+  tls_client_key     = "{{ boundary_transit_tls_key_file    |default('') }}"
+  tls_skip_verify    = "{{ boundary_transit_tls_skip_verify |default('false') }}"
 }
 {% endif %}
-
+{% endfor %}


### PR DESCRIPTION
Due to breaking changes this will have to be v2.0... still WiP, posting here so you can see where I'm going with this.

Add support for AWS and AEAD kms types
Break up KMS docs to simplify adding more
Break out group_vars and playbook docs to simplify README, allow contextual help
Breaking changes:
      - changed GCPCKMS crypto_key to a hash of key_type(s)
      - changed Transit key_name to a hash of key_type(s)
      - Renamed Transit TLS configuration variable names