### PR TITLE
WiP: Add listener configuration parameters, including TLS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,18 +40,38 @@ boundary_checksum_file_url: "{{ boundary_url }}/{{ boundary_version }}/{{ bounda
 # Database
 boundary_psql_dbname: boundary
 
-# Key management
+# TLS Listener management
 boundary_client_addr: '0.0.0.0'
 boundary_tls_disable: true
 boundary_cors_enabled: false
 boundary_disable_mlock: true
+# Keys should be parameter names from https://www.boundaryproject.io/docs/configuration/listener/tcp#tcp-listener-parameters
+boundary_tls_api_listener_parameters:
+boundary_tls_cluster_listener_parameters: {}
 
+# TLS keys and certificates
+boundary_tls_config_path: "{{ boundary_home_directory }}/tls" # used to create directory, or within other values
+boundary_tls_ca_file:     "{{ boundary_tls_config_path }}/ca_cert.pem"
+boundary_tls_cert_file:   "{{ boundary_tls_config_path }}/client_cert.pem"
+boundary_tls_key_file:    "{{ boundary_tls_config_path }}/client_key.pem"
+
+# This has been removed and replaced by a test for each file type
+#boundary_tls_copy_keys: true
+# in either src_(type)_file or (type)_content
+
+# Copy TLS files from local or remote
+boundary_tls_src_path: 'files/tls' # only used within other values below relative to the playbook
+boundary_tls_src_ca_file: "{{ boundary_tls_src_path }}/ca_cert.pem"
+#boundary_tls_src_ca_remote: false  # true to use remote file
+boundary_tls_src_cert_file: "{{ boundary_tls_src_path }}/client_cert.pem"
+#boundary_tls_src_cert_remote: false
+boundary_tls_src_key_file: "{{ boundary_tls_src_path }}/client_key.pem"
+#boundary_tls_src_key_remote: false
+
+# or provided the data from Ansible secret data sources
+#boundary_tls_ca_content: secret_provided_value
+#boundary_tls_cert_content: secret_provided_value
+#boundary_tls_keyt_content: secret_provided_value
+
+# KMS Configuration
 boundary_kms_type: 'gcpckms'
-
-boundary_tls_copy_keys: true
-boundary_tls_files_remote_src: false
-boundary_tls_src_files: 'files/tls'
-boundary_tls_config_path: "{{ boundary_home_directory }}/tls"
-boundary_tls_ca_file: ca_cert.pem
-boundary_tls_cert_file: client_cert.pem
-boundary_tls_key_file: client_key.pem

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -13,20 +13,27 @@
 - name: SSL Certificate and Key
   become: true
   copy:
-    remote_src: "{{ boundary_tls_files_remote_src }}"
+    remote_src: "{{ item.remote_src }}"
+    content: "{{ item.content }}"
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     owner: "{{ boundary_user }}"
     group: "{{ boundary_group }}"
     mode: "{{ item.mode }}"
+  when: item.dest != "" and (item.src != '' or item.content != '')
   with_items:
-    - src: "{{ boundary_tls_src_files }}/{{ boundary_tls_cert_file }}"
-      dest: "{{ boundary_tls_config_path }}/{{ boundary_tls_cert_file }}"
+    - src: "{{ boundary_tls_src_cert_file | default(null) }}"
+      dest: "{{ boundary_tls_cert_file }}"
+      remote_src: "{{ boundary_tls_src_cert_remote | default('false') }}"
+      content: "{{ boundary_tls_ca_content | default(null) }}"
       mode: "0644"
-    - src: "{{ boundary_tls_src_files }}/{{ boundary_tls_key_file }}"
-      dest: "{{ boundary_tls_config_path }}/{{ boundary_tls_key_file }}"
+    - src: "{{ boundary_tls_src key_file | default(null) }}"
+      dest: "{{ boundary_tls_key_file }}"
+      remote_src: "{{ boundary_tls_src_key_remote | default('false') }}"
+      content: "{{ boundary_tls_key_content | default(null) }}"
       mode: "0600"
     - src: "{{ boundary_tls_src_files }}/{{ boundary_tls_ca_file }}"
       dest: "{{ boundary_tls_config_path }}/{{ boundary_tls_ca_file }}"
+      remote_src: "{{ boundary_tls_src_ca_remote | default('false') }}"
+      content: "{{ boundary_tls_ca_content | default(null) }}"
       mode: "0644"
-  when: boundary_tls_copy_keys | bool

--- a/templates/boundary-controller.hcl.j2
+++ b/templates/boundary-controller.hcl.j2
@@ -16,7 +16,16 @@ listener "tcp" {
   # The purpose of this listener block
   purpose = "api"
 
-  tls_disable = {{ boundary_tls_disable | lower }}
+  # TLS configuration
+{% if boundary_tls_disable == "true" %}{% for controller in groups['controllers'] %}
+  tls_disable   = {{ boundary_tls_disable | lower }}
+{% else %}
+  tls_cert_file = "{{ boundary_tls_cert_file }}"
+  tls_key_file  = "{{ boundary_tls_key_file }}"
+{% endif %}
+{% for tls_option, value in boundary_tls_api_listener_parameters %}
+  {{ tls_option }} = "{{ value }}"
+{% endfor $}
 
   # Enable CORS for the Admin UI
   cors_enabled = {{ boundary_cors_enabled | lower }}
@@ -32,7 +41,17 @@ listener "tcp" {
   # The purpose of this listener
   purpose = "cluster"
 
-  tls_disable = {{ boundary_tls_disable | lower }}
+{% if boundary_tls_disable == "true" %}
+  tls_disable   = {{ boundary_tls_disable | lower }}
+{% else %}
+  tls_cert_file = "{{ boundary_tls_cert_file }}"
+  tls_key_file  = "{{ boundary_tls_key_file }}"
+{% endif %}
+{% for tls_option, value in boundary_tls_cluster_listener_parameters %}
+  {{ tls_option }} = "{{ value }}"
+{% endfor $}
+
+  # Enable CORS for the Admin UI
 }
 
 {% if boundary_kms_type == 'gcpckms' %}


### PR DESCRIPTION
another WiP I want to get in front of you. The current configuration has very fixed expectations of key/cert data sources. This PR is an attempt to allow the current config with the same defaults (non-breaking), while also allowing very diverse configurations which source the keys and certs from different places. I'd really like to see some thoughts and feedback from both of you.

- Add distinct listener configurations for api and cluster
- Allow tls key/certs to be created from secret data sources in addition to files
- Allow different sources for CA and certs