### PR TITLE
Update default version to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.1]
+
+### Fixed
+
+- Starting with version 8 boundary packages now have a release number after the version.
+
+### Changed
+
+- Default version is now 0.11.2-1
+
 ## [v2.0.0]
 
 ### Breaking Changes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Package installation
 boundary_install_package: true
-boundary_version: '0.7.5'
+boundary_version: '0.11.2-1'
 boundary_autocomplete_state: file  # can be changed to absent
 
 # Config files can be customized
@@ -78,6 +78,8 @@ boundary_client_addr: '0.0.0.0'
 boundary_tls_disable: false
 boundary_cors_enabled: false
 boundary_cors_allowed_origins: ['*']
+
+# Disable memory lock: https://www.man7.org/linux/man-pages/man2/mlock.2.html
 boundary_disable_mlock: true
 
 # Keys should be parameter names from listener docs


### PR DESCRIPTION
Adds a helpful comment from the default config into the default values file

Doing this to set up base before larger 0.12 changes land.